### PR TITLE
Changed hard-coded "Hi " to use translation

### DIFF
--- a/rsvp_frontend.inc.php
+++ b/rsvp_frontend.inc.php
@@ -555,7 +555,7 @@ function rsvp_find(&$output, &$text) {
 		// hey we found something, we should move on and print out any associated users and let them rsvp
 		$output = RSVP_START_CONTAINER;
 		if(strtolower($attendee->rsvpStatus) == "noresponse") {
-			$output .= RSVP_START_PARA."Hi ".htmlspecialchars(stripslashes($attendee->firstName." ".$attendee->lastName))."!".RSVP_END_PARA;
+			$output .= RSVP_START_PARA.__("Hi", 'rsvp-plugin')." ".htmlspecialchars(stripslashes($attendee->firstName." ".$attendee->lastName))."!".RSVP_END_PARA;
 						
 			if(trim(get_option(OPTION_WELCOME_TEXT)) != "") {
 				$output .= RSVP_START_PARA.trim(get_option(OPTION_WELCOME_TEXT)).RSVP_END_PARA;


### PR DESCRIPTION
I found that guests were greeted with "Hi" on the Swedish version of my web site even though that word was translated in other places of the RSVP plugin. This change works for me with version 2.0.3, but I normally write C#, so please review the change carefully.